### PR TITLE
Update table options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [0.7.0] - 2021-06-13
+
 ### Added
 
 - Add wrapper around sortable table header link and order direction indicator.
@@ -27,6 +29,7 @@
 - Omit `page=1` and `offset=0` when building query parameters.
 - Omit default values for order and limit/page size parameters when building
   query parameters.
+- Requires Flop `~> 0.11.0`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,28 @@
 
 ## Unreleased
 
-### Changed
+### Added
 
 - Add wrapper around sortable table header link and order direction indicator.
-- Add option `current_link_attrs` to pagination builder. The
-  `pagination_link_attrs` is not applied to current links anymore.
+- Add option `current_link_attrs` to pagination builder.
+- Add options `thead_tr_attrs`, `thead_th_attrs`, `tbody_tr_attrs` and
+  `tbody_td_attrs` to table generator.
+- Add option `no_results_content` to table generator, which sets the content
+  that is going to be displayed instead of the table if the item list is empty.
+  A default option is applied, so make sure to set the option and/or remove your
+  own no results messages from your templates when making the upgrade.
+
+### Changed
+
+- The table options `table_class`, `th_wrapper_class`, `symbol_class` and
+  `container_class` were replaced in favour of `table_attrs`,
+  `th_wrapper_attrs`, `symbol_attrs` and `container_attrs` for more flexibility
+  and consistency with the pagination generator. To update, rename the options
+  in your code and wrap the values in keyword lists with a `class` key
+  (e.g. `container_class: "table-container"` =>
+  `container_attrs: [class: "table-container"]`).
+- The `pagination_link_attrs` is not applied to current links anymore. Use
+  `current_link_attrs` to set the attributes for the current link.
 - Omit `page=1` and `offset=0` when building query parameters.
 - Omit default values for order and limit/page size parameters when building
   query parameters.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ application:
 ```elixir
 def deps do
   [
-    {:flop_phoenix, "~> 0.6.1"}
+    {:flop_phoenix, "~> 0.7.0"}
   ]
 end
 ```

--- a/lib/flop_phoenix.ex
+++ b/lib/flop_phoenix.ex
@@ -273,6 +273,21 @@ defmodule Flop.Phoenix do
   alias Flop.Phoenix.Pagination
   alias Flop.Phoenix.Table
 
+  @default_table_opts [
+    container: false,
+    container_attrs: [class: "table-container"],
+    no_results_content: content_tag(:p, do: "No results."),
+    symbol_asc: "▴",
+    symbol_attrs: [class: "order-direction"],
+    symbol_desc: "▾",
+    table_attrs: [],
+    tbody_td_attrs: [],
+    tbody_tr_attrs: [],
+    th_wrapper_attrs: [],
+    thead_th_attrs: [],
+    thead_tr_attrs: []
+  ]
+
   @doc """
   Generates a pagination element.
 
@@ -344,32 +359,59 @@ defmodule Flop.Phoenix do
 
   - `:for` - The schema module deriving `Flop.Schema`. If set, header links are
     only added for fields that are defined as sortable.
-  - `:table_class` - The CSS class for the `<table>` element. No default.
-  - `:th_wrapper_class` - The CSS class for the `<span>` element that wraps the
-    header link and the order direction symbol. No default.
-  - `:symbol_class` - The CSS class for the `<span>` element that wraps the
-    order direction indicator in the header columns. Defaults to
-    `"order-direction"`.
+    Default: `#{inspect(@default_table_opts[:for])}`.
+  - `:table_attrs` - The attributes for the `<table>` element.
+    Default: `#{inspect(@default_table_opts[:table_attrs])}`.
+  - `:th_wrapper_attrs` - The attributes for the `<span>` element that wraps the
+    header link and the order direction symbol.
+    Default: `#{inspect(@default_table_opts[:th_wrapper_attrs])}`.
+  - `:symbol_attrs` - The attributes for the `<span>` element that wraps the
+    order direction indicator in the header columns.
+    Default: `#{inspect(@default_table_opts[:symbol_attrs])}`.
   - `:symbol_asc` - The symbol that is used to indicate that the column is
-    sorted in ascending order. Defaults to `"▴"`.
+    sorted in ascending order.
+    Default: `#{inspect(@default_table_opts[:symbol_asc])}`.
   - `:symbol_desc` - The symbol that is used to indicate that the column is
-    sorted in ascending order. Defaults to `"▾"`.
-  - `:container` - Wraps the table in a `<div>` if `true`. Defaults to `false`.
-  - `:container_class` - The CSS class for the table container. Defaults to
-    `"table-container"`.
+    sorted in ascending order.
+    Default: `#{inspect(@default_table_opts[:symbol_desc])}`.
+  - `:container` - Wraps the table in a `<div>` if `true`.
+    Default: `#{inspect(@default_table_opts[:container])}`.
+  - `:container_attrs` - The attributes for the table container.
+    Default: `#{inspect(@default_table_opts[:container_attrs])}`.
+  - `:no_results_content` - Any content that should be rendered if there are no
+    results. Default: `<p>No results.</p>`.
+  - `:thead_tr_attrs`: Attributes to added to each `<tr>` tag within the
+    `<thead>`. Default: `#{inspect(@default_table_opts[:thead_tr_attrs])}`.
+  - `:thead_th_attrs`: Attributes to added to each `<th>` tag within the
+    `<thead>`. Default: `#{inspect(@default_table_opts[:thead_th_attrs])}`.
+  - `:tbody_tr_attrs`: Attributes to added to each `<tr>` tag within the
+    `<tbody>`. Default: `#{inspect(@default_table_opts[:tbody_tr_attrs])}`.
+  - `:tbody_td_attrs`: Attributes to added to each `<td>` tag within the
+    `<tbody>`. Default: `#{inspect(@default_table_opts[:tbody_td_attrs])}`.
 
   See the module documentation for examples.
   """
+
   @doc since: "0.6.0"
   @doc section: :generators
   @spec table(map) :: Phoenix.LiveView.Rendered.t()
   def table(assigns) do
+    assigns =
+      Map.update(
+        assigns,
+        :opts,
+        @default_table_opts,
+        &Keyword.merge(@default_table_opts, &1)
+      )
+
     ~L"""
-    <%= unless @items == [] do %>
+    <%= if @items == [] do %>
+      <%= @opts[:no_results_content] %>
+    <% else %>
       <%= if @opts[:container] do %>
-        <div class="<%= Keyword.get(@opts, :container_class, "table-container") %>">
+        <%= content_tag :div, @opts[:container_attrs] do %>
           <%= Table.render(assigns) %>
-        </div>
+        <% end %>
       <% else %>
         <%= Table.render(assigns) %>
       <% end %>

--- a/lib/flop_phoenix/table.ex
+++ b/lib/flop_phoenix/table.ex
@@ -7,24 +7,24 @@ defmodule Flop.Phoenix.Table do
 
   def render(assigns) do
     ~L"""
-    <table<%= if @opts[:table_class] do %> class="<%= @opts[:table_class] %>"<% end %>>
-      <thead>
-        <tr>
-          <%= for header <- @headers do %>
-            <%= header(header, @meta, @path_helper, @path_helper_args, @opts) %>
-          <% end %>
-        </tr>
+    <%= content_tag :table, @opts[:table_attrs] do %>
+      <thead><%=
+        content_tag :tr, @opts[:thead_tr_attrs] do %><%=
+          for header <- @headers do %><%=
+            header(header, @meta, @path_helper, @path_helper_args, @opts)
+          %><% end %>
+        <% end %>
       </thead>
       <tbody>
         <%= for item <- @items do %>
-          <tr>
-            <%= for column <- @row_func.(item, @opts) do %>
-              <td><%= column %></td>
+          <%= content_tag :tr, @opts[:tbody_tr_attrs] do %><%=
+            for column <- @row_func.(item, @opts) do %><%=
+              content_tag :td, @opts[:tbody_td_attrs] do %><%= column %><% end %>
             <% end %>
-          </tr>
+          <% end %>
         <% end %>
       </tbody>
-    </table>
+    <% end %>
     """
   end
 
@@ -46,9 +46,9 @@ defmodule Flop.Phoenix.Table do
     }
 
     ~L"""
-    <th>
+    <%= content_tag :th, @opts[:thead_th_attrs] do %>
       <%= if is_sortable?(field, opts[:for]) do %>
-        <span class="<%= @opts[:th_wrapper_class] %>">
+        <%= content_tag :span, @opts[:th_wrapper_attrs] do %>
           <%= live_patch(@value,
                 to:
                   Flop.Phoenix.build_path(
@@ -60,19 +60,17 @@ defmodule Flop.Phoenix.Table do
               )
           %>
           <%= @flop |> current_direction(@field) |> render_arrow(@opts) %>
-        </span>
-      <% else %>
-        <%= @value %>
-      <% end %>
-    </th>
+        <% end %>
+      <% else %><%= @value %><% end %>
+    <% end %>
     """
   end
 
-  defp header(value, _, _, _, _) do
-    assigns = %{__changed__: nil, value: value}
+  defp header(value, _, _, _, opts) do
+    assigns = %{__changed__: nil, opts: opts, value: value}
 
     ~L"""
-    <th><%= @value %></th>
+    <%= content_tag :th, @opts[:thead_th_attrs] do %><%= @value %><% end %>
     """
   end
 
@@ -87,13 +85,13 @@ defmodule Flop.Phoenix.Table do
     assigns = %{__changed__: nil, direction: direction, opts: opts}
 
     ~L"""
-    <span class="<%= @opts[:symbol_class] || "order-direction" %>"><%=
+    <%= content_tag :span, @opts[:symbol_attrs] do %><%=
       if @direction in [:asc, :asc_nulls_first, :asc_nulls_last] do
-        Keyword.get(@opts, :symbol_asc, "▴")
+        @opts[:symbol_asc]
       else
-        Keyword.get(@opts, :symbol_desc, "▾")
+        @opts[:symbol_desc]
       end
-    %></span>
+    %><% end %>
     """
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule FlopPhoenix.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/woylie/flop_phoenix"
-  @version "0.6.1"
+  @version "0.7.0"
 
   def project do
     [

--- a/test/flop_phoenix_test.exs
+++ b/test/flop_phoenix_test.exs
@@ -570,10 +570,11 @@ defmodule Flop.PhoenixTest do
       }
     end
 
-    test "allows to set table class", %{assigns: assigns} do
+    test "allows to set table attributes", %{assigns: assigns} do
       assert render_table(%{assigns | opts: []}) =~ ~s(<table>)
+      opts = [table_attrs: [class: "funky-table"]]
 
-      assert render_table(%{assigns | opts: [table_class: "funky-table"]}) =~
+      assert render_table(%{assigns | opts: opts}) =~
                ~s(<table class="funky-table">)
     end
 
@@ -585,12 +586,27 @@ defmodule Flop.PhoenixTest do
                ~s(<div class="table-container">)
     end
 
-    test "allows to set container class", %{assigns: assigns} do
-      assert render_table(%{
-               assigns
-               | opts: [container: true, container_class: "container"]
-             }) =~
-               ~s(<div class="container">)
+    test "allows to set container attributes", %{assigns: assigns} do
+      opts = [container: true, container_attrs: [class: "container", id: "a"]]
+
+      assert render_table(%{assigns | opts: opts}) =~
+               ~s(<div class="container" id="a">)
+    end
+
+    test "allows to set tr and td classes", %{assigns: assigns} do
+      opts = [
+        thead_tr_attrs: [class: "mungo"],
+        thead_th_attrs: [class: "bean"],
+        tbody_tr_attrs: [class: "salt"],
+        tbody_td_attrs: [class: "tolerance"]
+      ]
+
+      html = render_table(%{assigns | opts: opts})
+
+      assert html =~ ~s(<tr class="mungo"><th)
+      assert html =~ ~s(<th class="bean">)
+      assert html =~ ~s(<tr class="salt"><td)
+      assert html =~ ~s(<td class="tolerance">)
     end
 
     test "doesn't render table if items list is empty", %{assigns: assigns} do
@@ -662,13 +678,17 @@ defmodule Flop.PhoenixTest do
     end
 
     test "allows to set symbol class", %{assigns: assigns} do
+      meta = %Flop.Meta{
+        flop: %Flop{order_by: [:name], order_directions: [:asc]}
+      }
+
+      opts = [symbol_attrs: [class: "other-class"]]
+
       assert render_table(%{
                assigns
                | headers: [{"Name", :name}],
-                 meta: %Flop.Meta{
-                   flop: %Flop{order_by: [:name], order_directions: [:asc]}
-                 },
-                 opts: [symbol_class: "other-class"]
+                 meta: meta,
+                 opts: opts
              }) =~ ~s(<span class="other-class")
     end
 
@@ -707,6 +727,17 @@ defmodule Flop.PhoenixTest do
       assert html =~ ~s(<td>8</td>)
       assert html =~ ~s(<td>Barbara-chan</td>)
       assert html =~ ~s(<td>2</td>)
+    end
+
+    test "renders notice if item list is empty", %{assigns: assigns} do
+      html = render_table(%{assigns | items: []})
+      assert String.trim(html) == "<p>No results.</p>"
+    end
+
+    test "allows to set no_results_content", %{assigns: assigns} do
+      opts = [no_results_content: ~E"<div>Nothing!</div>"]
+      html = render_table(%{assigns | items: [], opts: opts})
+      assert String.trim(html) == "<div>Nothing!</div>"
     end
   end
 


### PR DESCRIPTION
- [x] add options to customise the `tr`, `th` and `td` attributes
- [x] add option to set a no-results message if the item list is empty
- [x] replace `_class` table options with `_attrs` options for consistency

resolves #29 