### PR TITLE
Implement form data

### DIFF
--- a/lib/flop_phoenix.ex
+++ b/lib/flop_phoenix.ex
@@ -630,4 +630,38 @@ defmodule Flop.Phoenix do
         args ++ [flop_params]
     end
   end
+
+  @doc """
+  Generates hidden inputs for the given form.
+
+  This does the same as `Phoenix.HTML.Form.hidden_inputs_for/1` in versions
+  <= 3.1.0, except that it supports list fields. If you use a later
+  `Phoenix.HTML` version, you don't need this function.
+  """
+  @doc since: "0.12.0"
+  @doc section: :components
+  @spec filter_hidden_inputs_for(Phoenix.HTML.Form.t()) ::
+          list(Phoenix.HTML.safe())
+  def filter_hidden_inputs_for(form) do
+    Enum.flat_map(form.hidden, fn {k, v} ->
+      filter_hidden_inputs_for(form, k, v)
+    end)
+  end
+
+  defp filter_hidden_inputs_for(form, k, values) when is_list(values) do
+    id = input_id(form, k)
+    name = input_name(form, k)
+
+    for {v, index} <- Enum.with_index(values) do
+      hidden_input(form, k,
+        id: id <> "_" <> Integer.to_string(index),
+        name: name <> "[]",
+        value: v
+      )
+    end
+  end
+
+  defp filter_hidden_inputs_for(form, k, v) do
+    [hidden_input(form, k, value: v)]
+  end
 end

--- a/lib/flop_phoenix/form_data.ex
+++ b/lib/flop_phoenix/form_data.ex
@@ -1,0 +1,143 @@
+defimpl Phoenix.HTML.FormData, for: Flop.Meta do
+  import Flop.Phoenix.Misc, only: [maybe_put: 3]
+
+  def to_form(meta, opts) do
+    {name, opts} = name_and_opts(meta, opts)
+    {errors, opts} = Keyword.pop(opts, :errors, [])
+    {hidden, opts} = Keyword.pop(opts, :hidden, [])
+    {params, opts} = Keyword.pop(opts, :params, %{})
+    id = Keyword.get(opts, :id) || name || "flop"
+
+    %Phoenix.HTML.Form{
+      data: meta.flop,
+      errors: errors,
+      hidden: hidden_inputs(meta.flop, hidden),
+      id: id,
+      impl: __MODULE__,
+      name: name,
+      options: opts,
+      params: params,
+      source: meta
+    }
+  end
+
+  def to_form(
+        meta,
+        %{data: %Flop{} = flop} = form,
+        :filters,
+        opts
+      ) do
+    no_unsupported_options!(opts)
+
+    {id, opts} = Keyword.pop(opts, :id)
+    {default, opts} = Keyword.pop(opts, :default, [])
+    {prepend, opts} = Keyword.pop(opts, :prepend, [])
+    {append, opts} = Keyword.pop(opts, :append, [])
+    {skip_hidden_op, opts} = Keyword.pop(opts, :skip_hidden_op, false)
+
+    name = if form.name, do: form.name <> "[filters]", else: "filters"
+    id = if id = id || form.id, do: to_string(id <> "_filters"), else: "filters"
+    filters = if flop.filters == [], do: default, else: flop.filters
+    filters = prepend ++ filters ++ append
+
+    for {filter, index} <- Enum.with_index(filters) do
+      index_string = Integer.to_string(index)
+
+      hidden =
+        if skip_hidden_op,
+          do: [field: filter.field],
+          else: [field: filter.field, op: filter.op]
+
+      %Phoenix.HTML.Form{
+        source: meta,
+        impl: __MODULE__,
+        index: index,
+        id: id <> "_" <> index_string,
+        name: name <> "[" <> index_string <> "]",
+        data: filter,
+        params: %{},
+        hidden: hidden,
+        options: opts
+      }
+    end
+  end
+
+  def to_form(_meta, _form, field, _opts) do
+    raise ArgumentError,
+          "Only :filters is supported on " <>
+            "inputs_for with Flop.Meta, got: #{inspect(field)}."
+  end
+
+  defp no_unsupported_options!(opts) do
+    if Keyword.has_key?(opts, :hidden) do
+      raise ArgumentError,
+            ":hidden is not supported on inputs_for with Flop.Meta."
+    end
+
+    if Keyword.has_key?(opts, :as) do
+      raise ArgumentError,
+            ":as is not supported on inputs_for with Flop.Meta."
+    end
+  end
+
+  defp name_and_opts(_meta, opts) do
+    case Keyword.pop(opts, :as) do
+      {nil, opts} -> {nil, opts}
+      {name, opts} -> {to_string(name), opts}
+    end
+  end
+
+  defp hidden_inputs(%Flop{} = flop, hidden) do
+    hidden
+    |> maybe_put(:order_by, flop.order_by)
+    |> maybe_put(:order_directions, flop.order_directions)
+    |> maybe_put(:page_size, flop.page_size)
+    |> maybe_put(:limit, flop.limit)
+    |> maybe_put(:first, flop.first)
+    |> maybe_put(:last, flop.last)
+  end
+
+  def input_type(_meta, _form, :after), do: :text_input
+  def input_type(_meta, _form, :before), do: :text_input
+  def input_type(_meta, _form, :first), do: :number_input
+  def input_type(_meta, _form, :last), do: :number_input
+  def input_type(_meta, _form, :limit), do: :number_input
+  def input_type(_meta, _form, :offset), do: :number_input
+  def input_type(_meta, _form, :page), do: :number_input
+  def input_type(_meta, _form, :page_size), do: :number_input
+  def input_type(_meta, _form, _field), do: :text_input
+
+  def input_validations(_meta, _form, :after), do: [maxlength: 100]
+  def input_validations(_meta, _form, :before), do: [maxlength: 100]
+  def input_validations(_meta, _form, :offset), do: [min: 0]
+  def input_validations(_meta, _form, :page), do: [min: 1]
+
+  def input_validations(_meta, %{source: %Flop.Meta{schema: nil}}, field)
+      when field in [:first, :last, :limit, :page_size],
+      do: [min: 1]
+
+  def input_validations(_meta, %{source: %Flop.Meta{schema: schema}}, field)
+      when field in [:first, :last, :limit, :page_size] do
+    if max_limit = Flop.get_option(:max_limit, for: schema) do
+      [min: 1, max: max_limit]
+    else
+      [min: 1]
+    end
+  end
+
+  def input_validations(_meta, _form, _field), do: []
+
+  def input_value(_meta, %{data: data, params: params}, field)
+      when is_atom(field) do
+    key = Atom.to_string(field)
+
+    case params do
+      %{^key => value} -> value
+      %{} -> Map.get(data, field)
+    end
+  end
+
+  def input_value(_meta, _form, field) do
+    raise ArgumentError, "expected field to be an atom, got: #{inspect(field)}"
+  end
+end

--- a/test/flop/form_data_test.exs
+++ b/test/flop/form_data_test.exs
@@ -1,0 +1,418 @@
+defmodule Flop.Phoenix.FormDataTest do
+  use ExUnit.Case
+
+  import Phoenix.HTML
+  import Phoenix.HTML.Form
+  import Flop.Phoenix.Factory
+
+  alias Flop.Filter
+  alias Flop.Phoenix.Pet
+  alias Phoenix.HTML.Form
+
+  defp form_to_html(meta, opts \\ [], function) do
+    meta
+    |> form_for("/", opts, function)
+    |> safe_to_string()
+    |> Floki.parse_fragment!()
+  end
+
+  describe "form_for/3" do
+    test "with meta struct" do
+      meta = build(:meta_on_first_page)
+
+      html =
+        form_to_html(meta, fn f ->
+          assert f.data == meta.flop
+          assert f.params == %{}
+          assert f.source == meta
+          ""
+        end)
+
+      assert [{"form", [{"action", "/"}, {"method", "post"}], _}] = html
+    end
+
+    test "with :as" do
+      form_to_html(build(:meta_on_first_page), [as: :flop], fn f ->
+        assert f.name == "flop"
+        assert f.id == "flop"
+        ""
+      end)
+    end
+
+    test "with :id" do
+      meta = build(:meta_on_first_page)
+      opts = [id: "flip", as: :flop]
+
+      html =
+        form_to_html(meta, opts, fn f ->
+          assert f.name == "flop"
+          assert f.id == "flip"
+          ""
+        end)
+
+      assert [
+               {"form", [{"action", "/"}, {"id", "flip"}, {"method", "post"}],
+                _}
+             ] = html
+    end
+
+    test "with hidden inputs" do
+      meta = build(:meta_on_first_page)
+
+      html =
+        form_to_html(meta, fn f ->
+          assert f.hidden == [page_size: meta.flop.page_size]
+          hidden_inputs_for(f)
+        end)
+
+      assert [input] = Floki.find(html, "input#flop_page_size")
+      assert Floki.attribute(input, "name") == ["page_size"]
+      assert Floki.attribute(input, "value") == ["#{meta.flop.page_size}"]
+
+      meta = build(:meta_on_first_page, flop: %Flop{limit: 15, page_size: nil})
+      %Form{hidden: [limit: 15]} = form_for(meta, "/")
+
+      meta = build(:meta_on_first_page, flop: %Flop{first: 20})
+      %Form{hidden: [first: 20]} = form_for(meta, "/")
+
+      meta = build(:meta_on_first_page, flop: %Flop{last: 25})
+      %Form{hidden: [last: 25]} = form_for(meta, "/")
+    end
+
+    test "with hidden inputs for order" do
+      meta =
+        build(:meta_on_first_page,
+          flop: %Flop{order_by: [:name, :age], order_directions: [:desc, :asc]}
+        )
+
+      html =
+        form_to_html(meta, fn f ->
+          assert f.hidden == [
+                   order_directions: [:desc, :asc],
+                   order_by: [:name, :age]
+                 ]
+
+          Flop.Phoenix.filter_hidden_inputs_for(f)
+        end)
+
+      assert [input] = Floki.find(html, "input#flop_order_by_0")
+      assert Floki.attribute(input, "name") == ["order_by[]"]
+      assert Floki.attribute(input, "value") == ["name"]
+
+      assert [input] = Floki.find(html, "input#flop_order_by_1")
+      assert Floki.attribute(input, "name") == ["order_by[]"]
+      assert Floki.attribute(input, "value") == ["age"]
+
+      assert [input] = Floki.find(html, "input#flop_order_directions_0")
+      assert Floki.attribute(input, "name") == ["order_directions[]"]
+      assert Floki.attribute(input, "value") == ["desc"]
+
+      assert [input] = Floki.find(html, "input#flop_order_directions_1")
+      assert Floki.attribute(input, "name") == ["order_directions[]"]
+      assert Floki.attribute(input, "value") == ["asc"]
+    end
+
+    test "with additional hidden inputs" do
+      meta = build(:meta_on_first_page)
+      opts = [hidden: [something: "else"]]
+      html = form_to_html(meta, opts, fn f -> hidden_inputs_for(f) end)
+      assert [_] = Floki.find(html, "input#flop_page_size")
+      assert [input] = Floki.find(html, "input#flop_something")
+      assert Floki.attribute(input, "name") == ["something"]
+      assert Floki.attribute(input, "value") == ["else"]
+    end
+
+    test "with :params" do
+      meta = build(:meta_on_first_page)
+
+      html =
+        form_to_html(meta, [params: %{"page_size" => 25}], fn f ->
+          number_input(f, :page_size)
+        end)
+
+      assert [input] = Floki.find(html, "input#flop_page_size")
+      assert Floki.attribute(input, "name") == ["page_size"]
+      assert Floki.attribute(input, "type") == ["number"]
+      assert Floki.attribute(input, "value") == ["25"]
+    end
+  end
+
+  describe "form_for/4" do
+    test "with filters" do
+      %{flop: %{filters: [filter]}} =
+        meta =
+        build(:meta_on_first_page,
+          flop: %Flop{
+            filters: [%Filter{field: :name, op: :like, value: "George"}]
+          }
+        )
+
+      html =
+        form_to_html(meta, fn f ->
+          inputs_for(f, :filters, fn fo ->
+            assert fo.data == filter
+            assert fo.hidden == [field: :name, op: :like]
+            assert fo.id == "flop_filters_0"
+            assert fo.index == 0
+            assert fo.name == "filters[0]"
+            text_input(fo, :value)
+          end)
+        end)
+
+      assert [input] = Floki.find(html, "input#flop_filters_0_field")
+      assert Floki.attribute(input, "name") == ["filters[0][field]"]
+      assert Floki.attribute(input, "type") == ["hidden"]
+      assert Floki.attribute(input, "value") == ["name"]
+
+      assert [input] = Floki.find(html, "input#flop_filters_0_op")
+      assert Floki.attribute(input, "name") == ["filters[0][op]"]
+      assert Floki.attribute(input, "type") == ["hidden"]
+      assert Floki.attribute(input, "value") == ["like"]
+
+      assert [input] = Floki.find(html, "input#flop_filters_0_value")
+      assert Floki.attribute(input, "name") == ["filters[0][value]"]
+      assert Floki.attribute(input, "type") == ["text"]
+      assert Floki.attribute(input, "value") == ["George"]
+    end
+
+    test "with filters and default option" do
+      meta = build(:meta_on_first_page, flop: %Flop{filters: []})
+
+      html =
+        form_to_html(meta, fn f ->
+          inputs_for(f, :filters, [default: [%Filter{field: :name}]], fn fo ->
+            assert fo.data == %Filter{field: :name, op: :==, value: nil}
+            assert fo.hidden == [field: :name, op: :==]
+            assert fo.id == "flop_filters_0"
+            assert fo.index == 0
+            assert fo.name == "filters[0]"
+            text_input(fo, :value)
+          end)
+        end)
+
+      assert [input] = Floki.find(html, "input#flop_filters_0_field")
+      assert Floki.attribute(input, "name") == ["filters[0][field]"]
+      assert Floki.attribute(input, "type") == ["hidden"]
+      assert Floki.attribute(input, "value") == ["name"]
+
+      assert [input] = Floki.find(html, "input#flop_filters_0_op")
+      assert Floki.attribute(input, "name") == ["filters[0][op]"]
+      assert Floki.attribute(input, "type") == ["hidden"]
+      assert Floki.attribute(input, "value") == ["=="]
+
+      assert [input] = Floki.find(html, "input#flop_filters_0_value")
+      assert Floki.attribute(input, "name") == ["filters[0][value]"]
+      assert Floki.attribute(input, "type") == ["text"]
+      assert Floki.attribute(input, "value") == []
+    end
+
+    test "with filters and prepend/append" do
+      meta =
+        build(:meta_on_first_page,
+          flop: %Flop{
+            filters: [%Filter{field: :name, op: :like, value: "George"}]
+          }
+        )
+
+      prepend = [%Filter{field: :age, op: :<=, value: 8}]
+      append = [%Filter{field: :species, op: :==, value: "dog"}]
+
+      html =
+        form_to_html(meta, fn f ->
+          inputs_for(f, :filters, [prepend: prepend, append: append], fn fo ->
+            text_input(fo, :value)
+          end)
+        end)
+
+      assert [input] = Floki.find(html, "input#flop_filters_0_field")
+      assert Floki.attribute(input, "name") == ["filters[0][field]"]
+      assert Floki.attribute(input, "type") == ["hidden"]
+      assert Floki.attribute(input, "value") == ["age"]
+
+      assert [input] = Floki.find(html, "input#flop_filters_1_field")
+      assert Floki.attribute(input, "name") == ["filters[1][field]"]
+      assert Floki.attribute(input, "type") == ["hidden"]
+      assert Floki.attribute(input, "value") == ["name"]
+
+      assert [input] = Floki.find(html, "input#flop_filters_2_field")
+      assert Floki.attribute(input, "name") == ["filters[2][field]"]
+      assert Floki.attribute(input, "type") == ["hidden"]
+      assert Floki.attribute(input, "value") == ["species"]
+    end
+
+    test "with filters and :id option" do
+      meta =
+        build(:meta_on_first_page,
+          flop: %Flop{
+            filters: [%Filter{field: :name, op: :like, value: "George"}]
+          }
+        )
+
+      html =
+        form_to_html(meta, fn f ->
+          inputs_for(f, :filters, [id: "f1ltah"], fn fo ->
+            assert fo.id == "f1ltah_filters_0"
+            assert fo.index == 0
+            assert fo.name == "filters[0]"
+            text_input(fo, :value)
+          end)
+        end)
+
+      assert [input] = Floki.find(html, "input#f1ltah_filters_0_field")
+      assert Floki.attribute(input, "name") == ["filters[0][field]"]
+
+      assert [input] = Floki.find(html, "input#f1ltah_filters_0_op")
+      assert Floki.attribute(input, "name") == ["filters[0][op]"]
+
+      assert [input] = Floki.find(html, "input#f1ltah_filters_0_value")
+      assert Floki.attribute(input, "name") == ["filters[0][value]"]
+    end
+
+    test "with filters and :name option on outer form" do
+      meta =
+        build(:meta_on_first_page,
+          flop: %Flop{
+            filters: [%Filter{field: :name, op: :like, value: "George"}]
+          }
+        )
+
+      html =
+        form_to_html(meta, [as: "f1ltah"], fn f ->
+          inputs_for(f, :filters, fn fo ->
+            assert fo.id == "f1ltah_filters_0"
+            assert fo.name == "f1ltah[filters][0]"
+            text_input(fo, :value)
+          end)
+        end)
+
+      assert [input] = Floki.find(html, "input#f1ltah_filters_0_field")
+      assert Floki.attribute(input, "name") == ["f1ltah[filters][0][field]"]
+
+      assert [input] = Floki.find(html, "input#f1ltah_filters_0_op")
+      assert Floki.attribute(input, "name") == ["f1ltah[filters][0][op]"]
+
+      assert [input] = Floki.find(html, "input#f1ltah_filters_0_value")
+      assert Floki.attribute(input, "name") == ["f1ltah[filters][0][value]"]
+    end
+
+    test "with filters and without hidden input for :op" do
+      meta =
+        build(:meta_on_first_page,
+          flop: %Flop{
+            filters: [%Filter{field: :name, op: :like, value: "George"}]
+          }
+        )
+
+      html =
+        form_to_html(meta, fn f ->
+          inputs_for(f, :filters, [skip_hidden_op: true], fn fo ->
+            assert fo.hidden == [field: :name]
+            [text_input(fo, :op), text_input(fo, :value)]
+          end)
+        end)
+
+      assert [input] = Floki.find(html, "input#flop_filters_0_op")
+      assert Floki.attribute(input, "name") == ["filters[0][op]"]
+      assert Floki.attribute(input, "type") == ["text"]
+      assert Floki.attribute(input, "value") == ["like"]
+    end
+
+    test "raises error with unsupported options" do
+      meta = build(:meta_on_first_page)
+
+      for opt <- [:hidden, :as] do
+        msg = ":#{opt} is not supported on inputs_for with Flop.Meta."
+
+        assert_raise ArgumentError, msg, fn ->
+          form_to_html(meta, fn f ->
+            inputs_for(f, :filters, [{opt, :whatever}], fn _ -> "" end)
+          end)
+        end
+      end
+    end
+
+    test "with unknown fields" do
+      meta = build(:meta_on_first_page)
+
+      msg =
+        "Only :filters is supported on " <>
+          "inputs_for with Flop.Meta, got: :something."
+
+      assert_raise ArgumentError, msg, fn ->
+        form_to_html(meta, fn f ->
+          inputs_for(f, :something, fn _ -> "" end)
+        end)
+      end
+    end
+  end
+
+  describe "input_type/2" do
+    test "returns input type depending on field" do
+      form_to_html(build(:meta_on_first_page), fn f ->
+        assert input_type(f, :after) == :text_input
+        assert input_type(f, :before) == :text_input
+        assert input_type(f, :first) == :number_input
+        assert input_type(f, :last) == :number_input
+        assert input_type(f, :limit) == :number_input
+        assert input_type(f, :offset) == :number_input
+        assert input_type(f, :page) == :number_input
+        assert input_type(f, :page_size) == :number_input
+        assert input_type(f, :anything_else) == :text_input
+        ""
+      end)
+    end
+  end
+
+  describe "input_validations/3" do
+    test "returns validations depending on field" do
+      form_to_html(build(:meta_on_first_page), fn f ->
+        assert input_validations(f, :first) == [min: 1]
+        assert input_validations(f, :last) == [min: 1]
+        assert input_validations(f, :limit) == [min: 1]
+        assert input_validations(f, :page_size) == [min: 1]
+
+        assert input_validations(f, :after) == [maxlength: 100]
+        assert input_validations(f, :before) == [maxlength: 100]
+        assert input_validations(f, :offset) == [min: 0]
+        assert input_validations(f, :page) == [min: 1]
+
+        assert input_validations(f, :anything_else) == []
+        ""
+      end)
+    end
+
+    test "applies :max_limit if schema is set" do
+      form_to_html(build(:meta_on_first_page, schema: Pet), fn f ->
+        assert input_validations(f, :first) == [min: 1, max: 200]
+        assert input_validations(f, :last) == [min: 1, max: 200]
+        assert input_validations(f, :limit) == [min: 1, max: 200]
+        assert input_validations(f, :page_size) == [min: 1, max: 200]
+        ""
+      end)
+    end
+  end
+
+  describe "input_value/2" do
+    test "returns value from flop struct" do
+      meta = build(:meta_on_first_page)
+
+      form_to_html(meta, fn f ->
+        assert input_value(f, :page_size) == meta.flop.page_size
+        assert input_value(f, :page) == meta.flop.page
+        ""
+      end)
+    end
+
+    test "raises error for string field" do
+      meta = build(:meta_on_first_page)
+      msg = ~s(expected field to be an atom, got: "page_size")
+
+      assert_raise ArgumentError, msg, fn ->
+        form_to_html(meta, fn f ->
+          assert input_value(f, "page_size")
+          ""
+        end)
+      end
+    end
+  end
+end

--- a/test/flop_phoenix_test.exs
+++ b/test/flop_phoenix_test.exs
@@ -1355,4 +1355,37 @@ defmodule Flop.PhoenixTest do
       refute Keyword.has_key?(query, :order_directions)
     end
   end
+
+  describe "filter_hidden_inputs_for/1" do
+    test "generates hidden fields from the given form" do
+      form = %{form_for(:form, "/") | hidden: [id: 1]}
+
+      assert filter_hidden_inputs_for(form) == [
+               hidden_input(form, :id, value: 1)
+             ]
+    end
+
+    test "generates hidden fields for lists from the given form" do
+      form = %{form_for(:a, "/") | hidden: [field: ["a", "b", "c"]]}
+
+      assert filter_hidden_inputs_for(form) ==
+               [
+                 hidden_input(form, :field,
+                   name: "a[field][]",
+                   id: "a_field_0",
+                   value: "a"
+                 ),
+                 hidden_input(form, :field,
+                   name: "a[field][]",
+                   id: "a_field_1",
+                   value: "b"
+                 ),
+                 hidden_input(form, :field,
+                   name: "a[field][]",
+                   id: "a_field_2",
+                   value: "c"
+                 )
+               ]
+    end
+  end
 end

--- a/test/support/pet.ex
+++ b/test/support/pet.ex
@@ -9,6 +9,7 @@ defmodule Flop.Phoenix.Pet do
     filterable: [:name, :age],
     sortable: [:name, :age],
     default_limit: 20,
+    max_limit: 200,
     default_order_by: [:name],
     default_order_directions: [:asc]
   }


### PR DESCRIPTION
This implements the `Phoenix.HTML.FormData` protocol for `Flop.Meta`, allowing you to pass the meta struct returned by Flop to `form_for`.