### PR TITLE
body_attrs

### DIFF
--- a/lib/flop_phoenix.ex
+++ b/lib/flop_phoenix.ex
@@ -238,6 +238,8 @@ defmodule Flop.Phoenix do
     Default: `#{inspect(Table.default_opts()[:symbol_desc])}`.
   - `:symbol_unsorted` - The symbol that is used to indicate that the column is
     not sorted. Default: `#{inspect(Table.default_opts()[:symbol_unsorted])}`.
+  - `:tbody_attrs`: Attributes to added to the `<tbody>` tag within the
+    `<table>`. Default: `#{inspect(Table.default_opts()[:tbody_attrs])}`.
   - `:tbody_td_attrs`: Attributes to added to each `<td>` tag within the
     `<tbody>`. Default: `#{inspect(Table.default_opts()[:tbody_td_attrs])}`.
   - `:tbody_tr_attrs`: Attributes to added to each `<tr>` tag within the
@@ -256,6 +258,7 @@ defmodule Flop.Phoenix do
           | {:symbol_desc, Phoenix.HTML.safe() | binary}
           | {:symbol_unsorted, Phoenix.HTML.safe() | binary}
           | {:table_attrs, keyword}
+          | {:tbody_attrs, keyword}
           | {:tbody_td_attrs, keyword}
           | {:tbody_tr_attrs, keyword}
           | {:th_wrapper_attrs, keyword}

--- a/lib/flop_phoenix/table.ex
+++ b/lib/flop_phoenix/table.ex
@@ -68,6 +68,7 @@ defmodule Flop.Phoenix.Table do
       symbol_desc: "▾",
       symbol_unsorted: nil,
       table_attrs: [],
+      tbody_attrs: [],
       tbody_td_attrs: [],
       tbody_tr_attrs: [],
       th_wrapper_attrs: [],
@@ -136,7 +137,7 @@ defmodule Flop.Phoenix.Table do
           <% end %>
         </tr>
       </thead>
-      <tbody>
+      <tbody {@opts[:tbody_attrs]}>
         <tr :for={item <- @items} {@opts[:tbody_tr_attrs]}>
           <%= for col <- @col do %>
             <%= if show_column?(col) do %>

--- a/test/flop_phoenix_test.exs
+++ b/test/flop_phoenix_test.exs
@@ -1386,6 +1386,18 @@ defmodule Flop.PhoenixTest do
       assert Floki.attribute(container, "id") == ["a"]
     end
 
+    test "allows to set tbody attributes" do
+      html =
+        render_table(
+          opts: [
+            tbody_attrs: [class: "mango_body"],
+            container: true
+          ]
+        )
+
+      assert [_] = Floki.find(html, "tbody.mango_body")
+    end
+
     test "allows to set tr and td classes" do
       html =
         render_table(


### PR DESCRIPTION
**Description**

[A concise description of the proposed changes and/or a reference to the Github
issue.](https://github.com/woylie/flop_phoenix/issues/129) Added the tbody_attrs to customize tbody attrs. Specifically for targeting rows with dividers etc.

Let me know if i've missed anything 

**Checklist**

- [ tick] I added tests that cover my proposed changes.
- [ tick] I updated the documentation related to my changes (if applicable).
