### PR TITLE
Hotfix/Phoenix liveview 0.18.3

### DIFF
--- a/lib/flop_phoenix.ex
+++ b/lib/flop_phoenix.ex
@@ -686,11 +686,6 @@ defmodule Flop.Phoenix do
       the respective column. You can set the `width`, `background` and `border`
       of a column this way.
       """
-
-    attr :rest, :global,
-      doc: """
-      Any additional attributes to pass to the `<td>`.
-      """
   end
 
   slot :foot,

--- a/lib/flop_phoenix.ex
+++ b/lib/flop_phoenix.ex
@@ -656,11 +656,6 @@ defmodule Flop.Phoenix do
       the respective column. You can set the `width`, `background` and `border`
       of a column this way.
       """
-
-    attr :rest, :global,
-      doc: """
-      Any additional attributes to pass to the `<td>`.
-      """
   end
 
   slot :action,


### PR DESCRIPTION
**Description**

Reference - https://github.com/woylie/flop_phoenix/issues/135.

Global attr not allowed in slot. Any global attrs still get passed in but now give warnings for example `class`. 

**Checklist**

- [ ] I added tests that cover my proposed changes.
- [ ] I updated the documentation related to my changes (if applicable).
