### PR TITLE
input type for join, compound, custom fields

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+.elixir_ls
+_build
+cover
+deps
+doc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Support `:as` option for filter inputs with `Phoenix.HTML.FormData/4`
   (`inputs_for`).
+- `Phoenix.HTML.FormData.input_type/2` now considers the Ecto type for join,
+  custom and compound fields.
 
 ## [0.17.2] - 2023-01-15
 

--- a/lib/flop_phoenix/form_data.ex
+++ b/lib/flop_phoenix/form_data.ex
@@ -203,7 +203,7 @@ defimpl Phoenix.HTML.FormData, for: Flop.Meta do
         :value
       )
       when not is_nil(schema) do
-    :type |> schema.__schema__(field) |> input_type_for_ecto_type()
+    schema |> ecto_type(field) |> input_type_for_ecto_type()
   end
 
   def input_type(_meta, _form, _field), do: :text_input
@@ -271,6 +271,16 @@ defimpl Phoenix.HTML.FormData, for: Flop.Meta do
     case map do
       %{^string_key => value} -> value
       %{} -> Map.get(map, key, default)
+    end
+  end
+
+  defp ecto_type(module, field) do
+    case module |> struct() |> Flop.Schema.field_type(field) do
+      {:normal, _} -> module.__schema__(:type, field)
+      {:join, %{ecto_type: type}} -> type
+      {:custom, %{ecto_type: type}} -> type
+      {:compound, _} -> :string
+      _ -> :string
     end
   end
 end

--- a/test/flop/form_data_test.exs
+++ b/test/flop/form_data_test.exs
@@ -538,7 +538,7 @@ defmodule Flop.Phoenix.FormDataTest do
       assert input_type(filter_form, :value) == :text_input
     end
 
-    test "returns input type depending on schema field type" do
+    test "returns input type depending on schema/flop field type" do
       mapping = [
         integer: :number_input,
         float: :text_input,
@@ -551,7 +551,11 @@ defmodule Flop.Phoenix.FormDataTest do
         naive_datetime: :datetime_select,
         naive_datetime_usec: :datetime_select,
         utc_datetime: :datetime_select,
-        utc_datetime_usec: :datetime_select
+        utc_datetime_usec: :datetime_select,
+        compound: :text_input,
+        join_default: :text_input,
+        join_integer: :number_input,
+        custom_date: :date_select
       ]
 
       filters = mapping |> Keyword.keys() |> Enum.map(&%Filter{field: &1})
@@ -590,9 +594,24 @@ defmodule Flop.Phoenix.FormDataTest do
         :naive_datetime,
         :naive_datetime_usec,
         :utc_datetime,
-        :utc_datetime_usec
+        :utc_datetime_usec,
+        :compound,
+        :join_default,
+        :join_integer,
+        :custom_date
       ],
-      sortable: []
+      sortable: [],
+      compound_fields: [compound: [:string, :string2]],
+      join_fields: [
+        join_default: [binding: :pets, field: :species],
+        join_integer: [binding: :pets, field: :species, ecto_type: :integer]
+      ],
+      custom_fields: [
+        custom_date: [
+          filter: {CustomFilters, :date_filter, []},
+          ecto_type: :date
+        ]
+      ]
     }
 
     schema "test_schema" do
@@ -600,6 +619,7 @@ defmodule Flop.Phoenix.FormDataTest do
       field(:float, :float)
       field(:boolean, :boolean)
       field(:string, :string)
+      field(:string2, :string)
       field(:decimal_field, :decimal)
       field(:date, :date)
       field(:time, :time)


### PR DESCRIPTION
- consider ecto type for join, custom, compound fields in input_type/2
- add prettierignore
