### PR TITLE
Add hidden attribute for tailwinds space-y issue

### DIFF
--- a/lib/flop_phoenix.ex
+++ b/lib/flop_phoenix.ex
@@ -1073,6 +1073,7 @@ defmodule Flop.Phoenix do
       id={input_id(@form, @field) <> "_#{index}"}
       name={input_name(@form, @field) <> "[]"}
       value={v}
+      hidden
     />
     """
   end
@@ -1084,6 +1085,7 @@ defmodule Flop.Phoenix do
       id={input_id(@form, @field)}
       name={input_name(@form, @field)}
       value={@value}
+      hidden
     />
     """
   end


### PR DESCRIPTION
**Description**
When we use tailwind divider class to separate the different filter section, the hidden input are taken into account.
to avoid that, a hidden attribute must be added to the node

https://v2.tailwindcss.com/docs/upgrading-to-v2#add-hidden-to-any-template-tags-within-space-or-divide-elements

It's a very specific fix 


**Checklist**

- [ ] I added tests that cover my proposed changes.
- [ ] I updated the documentation related to my changes (if applicable).
