### PR TITLE
Update flop_phoenix customization example

### DIFF
--- a/lib/flop_phoenix.ex
+++ b/lib/flop_phoenix.ex
@@ -18,7 +18,7 @@ defmodule Flop.Phoenix do
   are deep-merged into the default options.
 
       defmodule MyAppWeb.CoreComponents do
-        import Phoenix.HTML
+        import Phoenix.HTML.Tag
 
         def pagination_opts do
            [


### PR DESCRIPTION
This PR just fixes a broken import in the customization example code, as the `tag` and `content_tag` helpers are housed in the Phoenix.HTML.Tag module and were resulting in compilation failures when bringing the example code into a phoenix project's CoreComponents

**Checklist**

- [x] I added tests that cover my proposed changes.
  - N/A
- [x] I updated the documentation related to my changes (if applicable).
