### PR TITLE
Update table component to allow passage of opts[:thead_attrs]

### DIFF
--- a/lib/flop_phoenix.ex
+++ b/lib/flop_phoenix.ex
@@ -242,6 +242,8 @@ defmodule Flop.Phoenix do
     `<table>`. Default: `#{inspect(Table.default_opts()[:tbody_attrs])}`.
   - `:tbody_td_attrs`: Attributes to be added to each `<td>` tag within the
     `<tbody>`. Default: `#{inspect(Table.default_opts()[:tbody_td_attrs])}`.
+  - `:thead_attrs`: Attributes to be added to the `<thead>` tag within the
+    `<table>`. Default: `#{inspect(Table.default_opts()[:thead_attrs])}`.
   - `:tbody_tr_attrs`: Attributes to be added to each `<tr>` tag within the
     `<tbody>`. Default: `#{inspect(Table.default_opts()[:tbody_tr_attrs])}`.
   - `:thead_th_attrs`: Attributes to be added to each `<th>` tag within the
@@ -259,6 +261,7 @@ defmodule Flop.Phoenix do
           | {:symbol_unsorted, Phoenix.HTML.safe() | binary}
           | {:table_attrs, keyword}
           | {:tbody_attrs, keyword}
+          | {:thead_attrs, keyword}
           | {:tbody_td_attrs, keyword}
           | {:tbody_tr_attrs, keyword}
           | {:th_wrapper_attrs, keyword}

--- a/lib/flop_phoenix/table.ex
+++ b/lib/flop_phoenix/table.ex
@@ -72,6 +72,7 @@ defmodule Flop.Phoenix.Table do
       tbody_attrs: [],
       tbody_td_attrs: [],
       tbody_tr_attrs: [],
+      thead_attrs: [],
       th_wrapper_attrs: [],
       thead_th_attrs: [],
       thead_tr_attrs: []
@@ -140,7 +141,7 @@ defmodule Flop.Phoenix.Table do
           <col :if={show_column?(action)} style={action[:col_style]} />
         <% end %>
       </colgroup>
-      <thead>
+      <thead {@opts[:thead_attrs]}>
         <tr {@opts[:thead_tr_attrs]}>
           <%= for col <- @col do %>
             <.header_column

--- a/test/flop_phoenix_test.exs
+++ b/test/flop_phoenix_test.exs
@@ -1454,6 +1454,18 @@ defmodule Flop.PhoenixTest do
       assert [_] = Floki.find(html, "tbody.mango_body")
     end
 
+    test "setting thead attributes" do
+      html =
+        render_table(
+          opts: [
+            thead_attrs: [class: "text-left text-zinc-500 leading-6"],
+            container: true
+          ]
+        )
+
+      assert [_] = Floki.find(html, "thead.text-left.text-zinc-500.leading-6")
+    end
+
     test "allows to set id on tbody" do
       html = render_table(id: "some-id")
       assert [_] = Floki.find(html, "tbody#some-id")


### PR DESCRIPTION
This pull request enables the passage of custom attributes to the `thead` element of flop_phoenix tables via `opts[:thead_attrs]`, which is particularly useful for custom styling, and is consistent with the `opts[:tbody_attrs]` option

**Checklist**

- [x] I added tests that cover my proposed changes.
- [x] I updated the documentation related to my changes (if applicable).
