### PR TITLE
feat(labels): add support for passing Phoenix.HTML.Safe to <:col> slot label arguments

### DIFF
--- a/lib/flop_phoenix.ex
+++ b/lib/flop_phoenix.ex
@@ -1014,7 +1014,7 @@ defmodule Flop.Phoenix do
     Any additional assigns will be added as attributes to the `<td>` elements.
 
     """ do
-    attr :label, :string, doc: "The content for the header column."
+    attr :label, :any, doc: "The content for the header column."
 
     attr :field, :atom,
       doc: """

--- a/lib/flop_phoenix/table.ex
+++ b/lib/flop_phoenix/table.ex
@@ -167,7 +167,7 @@ defmodule Flop.Phoenix.Table do
 
   attr :meta, Flop.Meta, required: true
   attr :field, :atom, required: true
-  attr :label, :string, required: true
+  attr :label, :any, required: true
   attr :path, :any, required: true
   attr :on_sort, JS
   attr :event, :string, required: true

--- a/test/flop_phoenix_test.exs
+++ b/test/flop_phoenix_test.exs
@@ -2997,6 +2997,36 @@ defmodule Flop.PhoenixTest do
       assert Floki.attribute(input, "type") == ["tel"]
     end
 
+    test "it overrides label when passed Phoenix.HTML.Safe" do
+      assigns = %{
+        meta: %Flop.Meta{flop: %Flop{}, schema: MyApp.Pet},
+        items: [%{name: "George", age: 8}],
+        opts: [],
+        thead_label_component: fn assigns ->
+          ~H"""
+          <div data-test-id="thead-label-component">
+            Custom
+          </div>
+          """
+        end
+      }
+
+      html =
+        parse_heex(~H"""
+        <Flop.Phoenix.table items={@items} meta={@meta} on_sort={%JS{}} opts={@opts}>
+          <:col :let={i} label={@thead_label_component.(%{})}>
+            <%= i.name %>
+          </:col>
+        </Flop.Phoenix.table>
+        """)
+
+      assert [
+               {"div", [{"data-test-id", "thead-label-component"}],
+                ["\n  Custom\n"]}
+             ] =
+               Floki.find(html, ~s([data-test-id="thead-label-component"]))
+    end
+
     test "renders multiple inputs for the same field", %{
       meta: meta
     } do


### PR DESCRIPTION
**Description**

Adds support for 

Passing `Phoenix.HTML.Safe` to label.

**Checklist**

- [x] I added tests that cover my proposed changes.
- [x] I updated the documentation related to my changes (if applicable).
