### PR TITLE
Flop.Phoenix.pagination change to allow not to render next/prev links

### DIFF
--- a/lib/flop_phoenix.ex
+++ b/lib/flop_phoenix.ex
@@ -186,7 +186,8 @@ defmodule Flop.Phoenix do
     Default: `#{inspect(Pagination.default_opts()[:wrapper_attrs])}`.
   """
   @type pagination_option ::
-          {:current_link_attrs, keyword}
+          {:render_next_and_previous_links, boolean()}
+          | {:current_link_attrs, keyword}
           | {:disabled_class, String.t()}
           | {:ellipsis_attrs, keyword}
           | {:ellipsis_content, Phoenix.HTML.safe() | binary}
@@ -429,6 +430,7 @@ defmodule Flop.Phoenix do
     ~H"""
     <nav :if={@meta.errors == [] && @meta.total_pages > 1} {@opts[:wrapper_attrs]}>
       <.pagination_link
+        :if={@opts[:render_next_and_previous_links]}
         disabled={!@meta.has_previous_page?}
         disabled_class={@opts[:disabled_class]}
         event={@event}
@@ -441,6 +443,7 @@ defmodule Flop.Phoenix do
         <%= @opts[:previous_link_content] %>
       </.pagination_link>
       <.pagination_link
+        :if={@opts[:render_next_and_previous_links]}
         disabled={!@meta.has_next_page?}
         disabled_class={@opts[:disabled_class]}
         event={@event}

--- a/lib/flop_phoenix/pagination.ex
+++ b/lib/flop_phoenix/pagination.ex
@@ -8,6 +8,7 @@ defmodule Flop.Phoenix.Pagination do
   @spec default_opts() :: [Flop.Phoenix.pagination_option()]
   def default_opts do
     [
+      render_next_and_previous_links: true,
       current_link_attrs: [
         class: "pagination-link is-current",
         aria: [current: "page"]

--- a/test/flop_phoenix_test.exs
+++ b/test/flop_phoenix_test.exs
@@ -101,6 +101,22 @@ defmodule Flop.PhoenixTest do
              """) == []
     end
 
+    test "does not render next and previous links if user specifies not to" do
+      assigns = %{meta: build(:meta_on_first_page)}
+
+      html =
+        parse_heex(~H"""
+        <Flop.Phoenix.pagination
+          meta={@meta}
+          on_paginate={%JS{}}
+          opts={[render_next_and_previous_links: false]}
+        />
+        """)
+
+      assert [] = Floki.find(html, ".pagination-next")
+      assert [] = Floki.find(html, ".pagination-previous")
+    end
+
     test "allows to overwrite wrapper class" do
       assigns = %{meta: build(:meta_on_first_page)}
 
@@ -3023,8 +3039,7 @@ defmodule Flop.PhoenixTest do
       assert [
                {"div", [{"data-test-id", "thead-label-component"}],
                 ["\n  Custom\n"]}
-             ] =
-               Floki.find(html, ~s([data-test-id="thead-label-component"]))
+             ] = Floki.find(html, ~s([data-test-id="thead-label-component"]))
     end
 
     test "renders multiple inputs for the same field", %{


### PR DESCRIPTION
**Description**

Thanks for making this awesome library!

This PR adds the ability to specify that you do not wanter to render next and previous links.

Background: we're experiencing a styling conflict with our UI library daisyUI that causes the nubmered pages left border radius to get cut off when next / prev links are rendered (which we do not want).

<img width="336" alt="image" src="https://github.com/woylie/flop_phoenix/assets/4985726/1ffd447b-427a-4c04-8843-41b8b58f3ae8">

This feature allows you to disable rendering those buttons if they aren't wanted.

**Checklist**

- [ x] I added tests that cover my proposed changes.
- [ x] I updated the documentation related to my changes (if applicable). 

