### PR TITLE
add `:no_results_attrs` opt, add empty row

### DIFF
--- a/lib/flop_phoenix/table.ex
+++ b/lib/flop_phoenix/table.ex
@@ -15,6 +15,7 @@ defmodule Flop.Phoenix.Table do
       container: false,
       container_attrs: [class: "table-container"],
       no_results_content: HTML.Tag.content_tag(:p, do: "No results."),
+      no_results_attrs: [class: "hidden only:table-row"],
       symbol_asc: "▴",
       symbol_attrs: [class: "order-direction"],
       symbol_desc: "▾",
@@ -135,6 +136,14 @@ defmodule Flop.Phoenix.Table do
             {merge_td_attrs(@opts[:tbody_td_attrs], action, item)}
           >
             <%= render_slot(action, @row_item.(item)) %>
+          </td>
+        </tr>
+        <tr id={@id <> "-empty-tr"} {@opts[:no_results_attrs]}>
+          <td
+            colspan={length(@col) + length(@action || 0)}
+            {@opts[:tbody_td_attrs] |> Keyword.update(:class, "", & "#{&1} text-center")}
+          >
+            <%= @opts[:no_results_content] %>
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
**Description**

When a Flop table has no rows in the table body, there is no messaging about empty contents. Although, `:no_results_content` is listed as an option, it appears to have no impact on the UI.

This PR adds a `:no_results_attrs` option and a new `<tr>` that is rendered when there are no `@items`. This solution works with both lists and LiveStreams.

**Checklist**

- [ ] I added tests that cover my proposed changes.
- [ ] I updated the documentation related to my changes (if applicable).


![image](https://github.com/woylie/flop_phoenix/assets/13895134/7c9e2b0e-20ee-4cce-9b66-0acc8b0c807c)

![image](https://github.com/woylie/flop_phoenix/assets/13895134/553d571f-6f84-4ed8-8ea9-83b805d4d03c)


