### PR TITLE
Add conditions in wrapped li instead of .pagination_link

### DIFF
--- a/lib/flop_phoenix.ex
+++ b/lib/flop_phoenix.ex
@@ -487,9 +487,8 @@ defmodule Flop.Phoenix do
 
     ~H"""
     <ul :if={@opts[:page_links] != :hide} {@opts[:pagination_list_attrs]}>
-      <li>
+      <li :if={@first > 1}>
         <.pagination_link
-          :if={@first > 1}
           event={@event}
           target={@target}
           page={1}
@@ -522,9 +521,8 @@ defmodule Flop.Phoenix do
         <span {@opts[:ellipsis_attrs]}><%= @opts[:ellipsis_content] %></span>
       </li>
 
-      <li>
+      <li :if={@last < @meta.total_pages}>
         <.pagination_link
-          :if={@last < @meta.total_pages}
           event={@event}
           target={@target}
           page={@meta.total_pages}


### PR DESCRIPTION
**Description**

Do not insert an empty `<li>` when the conditions for `<.pagination_link>` aren't met.

A concise description of the proposed changes and/or a reference to the Github
issue.
Move the conditional check to `<li>` from `<.pagintion_link>`
**Checklist**

- [ ] I added tests that cover my proposed changes. (not required)
- [ ] I updated the documentation related to my changes (if applicable).
