### PR TITLE
fix: add missing fields attribute in filter form example

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ straightforward way to render a filter form is through the
 `Flop.Phoenix.filter_fields/1` component, as shown below:
 
 ```elixir
+attr :fields, :list, required: true
 attr :meta, Flop.Meta, required: true
 attr :id, :string, default: nil
 attr :on_change, :string, default: "update-filter"
@@ -156,7 +157,7 @@ def filter_form(%{meta: meta} = assigns) do
     phx-change={@on_change}
     phx-submit={@on_change}
   >
-    <.filter_fields :let={i} form={@form} fields={[:email, :name]}>
+    <.filter_fields :let={i} form={@form} fields={@fields}>
       <.input
         field={i.field}
         label={i.label}


### PR DESCRIPTION
resolves #291 