### PR TITLE
Fix a bug in form field filtering

### DIFF
--- a/lib/flop_phoenix.ex
+++ b/lib/flop_phoenix.ex
@@ -1378,9 +1378,20 @@ defmodule Flop.Phoenix do
   end
 
   defp inputs_for_filters(form, fields, field_opts) do
-    form.source
-    |> form.impl.to_form(form, :filters, fields: fields)
-    |> Enum.zip(field_opts)
+    fields
+    |> Enum.with_index()
+    |> Enum.reduce([], fn {field, index}, acc ->
+      field_form = form.source
+      |> form.impl.to_form(form, :filters, fields: [field])
+
+      if Enum.count(field_form) > 0 do
+        field_opt = Enum.at(field_opts, index)
+        [{Enum.at(field_form, 0), field_opt} | acc]
+      else
+        acc
+      end
+    end)
+    |> Enum.reverse()
   end
 
   defp normalize_filter_fields(fields) do


### PR DESCRIPTION
Fixes #204 

The original implementation of the inputs_for_filters function indiscriminately zipped together the fields requested for filtering with their corresponding options without verifying if each field was actually permitted for filtering based on the form's schema.

If the fields requested were [1,2,3] and to_form returned only [2,3] then these two lists would be zipped together resulting in something like [[1,2], [2,3]] instead of [1,1],[2,2]. 

To fix loop through the fields individually, call to_form on them and only combine them with the opts if to_form returns something.

