### PR TITLE
Support attributes on list items in pagination.

### DIFF
--- a/lib/flop_phoenix.ex
+++ b/lib/flop_phoenix.ex
@@ -191,6 +191,8 @@ defmodule Flop.Phoenix do
     Default: `#{inspect(Pagination.default_opts()[:pagination_link_attrs])}`.
   - `:pagination_list_attrs` - The attributes for the pagination list.
     Default: `#{inspect(Pagination.default_opts()[:pagination_list_attrs])}`.
+  - `:pagination_list_item_attrs` - The attributes for the pagination list items.
+    Default: `#{inspect(Pagination.default_opts()[:pagination_list_item_attrs])}`.
   - `:previous_link_attrs` - The attributes for the link to the previous page.
     Default: `#{inspect(Pagination.default_opts()[:previous_link_attrs])}`.
   - `:previous_link_content` - The content for the link to the previous page.
@@ -210,6 +212,7 @@ defmodule Flop.Phoenix do
           | {:pagination_link_aria_label, (pos_integer -> binary)}
           | {:pagination_link_attrs, keyword}
           | {:pagination_list_attrs, keyword}
+          | {:pagination_list_item_attrs, keyword}
           | {:previous_link_attrs, keyword}
           | {:previous_link_content, Phoenix.HTML.safe() | binary}
           | {:wrapper_attrs, keyword}
@@ -501,7 +504,7 @@ defmodule Flop.Phoenix do
 
     ~H"""
     <ul :if={@opts[:page_links] != :hide} {@opts[:pagination_list_attrs]}>
-      <li :if={@first > 1}>
+      <li :if={@first > 1} {@opts[:pagination_list_item_attrs]}>
         <.pagination_link
           event={@event}
           target={@target}
@@ -514,11 +517,11 @@ defmodule Flop.Phoenix do
         </.pagination_link>
       </li>
 
-      <li :if={@first > 2}>
+      <li :if={@first > 2} {@opts[:pagination_list_item_attrs]}>
         <span {@opts[:ellipsis_attrs]}><%= @opts[:ellipsis_content] %></span>
       </li>
 
-      <li :for={page <- @range}>
+      <li :for={page <- @range} {@opts[:pagination_list_item_attrs]}>
         <.pagination_link
           event={@event}
           target={@target}
@@ -535,7 +538,7 @@ defmodule Flop.Phoenix do
         <span {@opts[:ellipsis_attrs]}><%= @opts[:ellipsis_content] %></span>
       </li>
 
-      <li :if={@last < @meta.total_pages}>
+      <li :if={@last < @meta.total_pages} {@opts[:pagination_list_item_attrs]}>
         <.pagination_link
           event={@event}
           target={@target}

--- a/lib/flop_phoenix/pagination.ex
+++ b/lib/flop_phoenix/pagination.ex
@@ -24,6 +24,7 @@ defmodule Flop.Phoenix.Pagination do
       pagination_link_aria_label: &"Go to page #{&1}",
       pagination_link_attrs: [class: "pagination-link"],
       pagination_list_attrs: [class: "pagination-list"],
+      pagination_list_item_attrs: [],
       previous_link_attrs: [
         aria: [label: "Go to previous page"],
         class: "pagination-previous"

--- a/test/flop_phoenix_test.exs
+++ b/test/flop_phoenix_test.exs
@@ -603,6 +603,22 @@ defmodule Flop.PhoenixTest do
       assert attribute(list, "title") == "boop"
     end
 
+    test "allows to overwrite pagination list item attributes" do
+      assigns = %{meta: build(:meta_on_first_page)}
+
+      html =
+        parse_heex(~H"""
+        <Flop.Phoenix.pagination
+          meta={@meta}
+          path="/pets"
+          opts={[pagination_list_item_attrs: [class: "p-list-item"]]}
+        />
+        """)
+
+      assert list_item = find_one(html, "ul li:first-child")
+      assert attribute(list_item, "class") == "p-list-item"
+    end
+
     test "allows to overwrite pagination link attributes" do
       assigns = %{meta: build(:meta_on_second_page)}
 


### PR DESCRIPTION
Unfortunately PR #307 has never been merged until today. However, I also need the functionality to set a specific CSS class for list items in order to support Bootstrap 5 pagination.

This PR incorporates code review suggestions from #307. Furthermore, the new pagination option `pagination_list_item_attrs` is also covered by a test.