### PR TITLE
Fix pagination_list_item_attrs missing from right ellipsis list item

### DIFF
--- a/lib/flop_phoenix.ex
+++ b/lib/flop_phoenix.ex
@@ -534,7 +534,7 @@ defmodule Flop.Phoenix do
         </.pagination_link>
       </li>
 
-      <li :if={@last < @meta.total_pages - 1}>
+      <li :if={@last < @meta.total_pages - 1} {@opts[:pagination_list_item_attrs]}>
         <span {@opts[:ellipsis_attrs]}><%= @opts[:ellipsis_content] %></span>
       </li>
 

--- a/test/flop_phoenix_test.exs
+++ b/test/flop_phoenix_test.exs
@@ -604,19 +604,22 @@ defmodule Flop.PhoenixTest do
     end
 
     test "allows to overwrite pagination list item attributes" do
-      assigns = %{meta: build(:meta_on_first_page)}
+      assigns = %{
+        meta: build(:meta_on_first_page, current_page: 12, total_pages: 20),
+        opts: [
+          page_links: {:ellipsis, 6},
+          pagination_list_item_attrs: [class: "p-list-item"]
+        ]
+      }
 
       html =
         parse_heex(~H"""
-        <Flop.Phoenix.pagination
-          meta={@meta}
-          path="/pets"
-          opts={[pagination_list_item_attrs: [class: "p-list-item"]]}
-        />
+        <Flop.Phoenix.pagination meta={@meta} path="/pets" opts={@opts} />
         """)
 
-      assert list_item = find_one(html, "ul li:first-child")
-      assert attribute(list_item, "class") == "p-list-item"
+      for list_item <- Floki.find(html, "ul li") do
+        assert attribute(list_item, "class") == "p-list-item"
+      end
     end
 
     test "allows to overwrite pagination link attributes" do


### PR DESCRIPTION
This commit adds the `pagination_list_item_attrs` option to the right ellipsis list item.
The test to cover this only verified that the first list child had the assigned options.
I've changed it to verify all list items, and added opts to trigger ellipsis rendering.

This was missing from the #337 PR that introduced `pagination_list_item_attrs`.