### PR TITLE
Honour :no_results_content option in case of empty stream

### DIFF
--- a/lib/flop_phoenix.ex
+++ b/lib/flop_phoenix.ex
@@ -1177,7 +1177,7 @@ defmodule Flop.Phoenix do
       |> assign_new(:id, fn -> table_id(meta.schema) end)
 
     ~H"""
-    <%= if @items == [] do %>
+    <%= if Enum.count(@items) == 0 do %>
       <%= @opts[:no_results_content] %>
     <% else %>
       <%= if @opts[:container] do %>

--- a/test/flop_phoenix_test.exs
+++ b/test/flop_phoenix_test.exs
@@ -2562,6 +2562,15 @@ defmodule Flop.PhoenixTest do
              }) == [{"div", [], ["Nothing!"]}]
     end
 
+    test "allows to set no_results_content if items is a stream" do
+      assert render_table(%{
+               items: Phoenix.LiveView.LiveStream.new(:emtpy, "empty", [], []),
+               opts: [
+                 no_results_content: custom_no_results_content()
+               ]
+             }) == [{"div", [], ["Nothing!"]}]
+    end
+
     test "renders row_click" do
       assigns = %{}
 


### PR DESCRIPTION
This is a small one. 
Leverages the fact that LiveStream implements Enumerable, in particular `count/1`.
Extended Tests for this. 