### PR TITLE
Raise on incorrect pagination component type

### DIFF
--- a/lib/flop_phoenix.ex
+++ b/lib/flop_phoenix.ex
@@ -433,6 +433,11 @@ defmodule Flop.Phoenix do
     raise Flop.Phoenix.PathOrJSError, component: :pagination
   end
 
+  def pagination(%{meta: %{start_cursor: start_cursor, end_cursor: end_cursor}})
+      when not is_nil(start_cursor) or not is_nil(end_cursor) do
+    raise Flop.Phoenix.IncorrectPaginationTypeError, component: :pagination
+  end
+
   def pagination(%{meta: meta, opts: opts, path: path} = assigns) do
     assigns =
       assigns
@@ -781,6 +786,13 @@ defmodule Flop.Phoenix do
 
   def cursor_pagination(%{path: nil, on_paginate: nil, event: nil}) do
     raise Flop.Phoenix.PathOrJSError, component: :cursor_pagination
+  end
+
+  def cursor_pagination(%{
+        meta: %{total_count: total_count, total_pages: total_pages}
+      })
+      when not is_nil(total_count) or not is_nil(total_pages) do
+    raise Flop.Phoenix.IncorrectPaginationTypeError, component: :pagination
   end
 
   def cursor_pagination(%{opts: opts} = assigns) do

--- a/lib/flop_phoenix/errors.ex
+++ b/lib/flop_phoenix/errors.ex
@@ -105,20 +105,17 @@ end
 
 defmodule Flop.Phoenix.IncorrectPaginationTypeError do
   @moduledoc """
-  Raised when a cursor result set meta is provided to the non-cursor
-  pagination or table component.
+  Raised when the pagination type used for a query is not supported by a
+  component.
   """
   defexception [:component]
 
   def message(%{component: _component}) do
     """
-    Pagination component type does not match result set type.
+    Pagination type not supported by component
 
-    Use the apprepriate pagination component for your result set.
-
-    Examples:
-        <Flop.Phoenix.pagination meta={@meta} path={~p"/pets"} /> for offset-paginated sets.
-        <Flop.Phoenix.cursor_pagination meta={@meta} path={~p"/pets"} /> for cursor-paginated sets.
+    - For page-based pagination, use `Flop.Phoenix.pagination/1`.
+    - For cursor-based pagination, use `Flop.Phoenix.cursor_pagination/1`.
     """
   end
 end

--- a/lib/flop_phoenix/errors.ex
+++ b/lib/flop_phoenix/errors.ex
@@ -102,3 +102,23 @@ defmodule Flop.Phoenix.PathOrJSError do
   defp on_examples(:table), do: "on_sort={JS.push(\"sort-table\")}"
   defp on_examples(_), do: "on_paginate={JS.push(\"paginate\")}"
 end
+
+defmodule Flop.Phoenix.IncorrectPaginationTypeError do
+  @moduledoc """
+  Raised when a cursor result set meta is provided to the non-cursor
+  pagination or table component.
+  """
+  defexception [:component]
+
+  def message(%{component: _component}) do
+    """
+    Pagination component type does not match result set type.
+
+    Use the apprepriate pagination component for your result set.
+
+    Examples:
+        <Flop.Phoenix.pagination meta={@meta} path={~p"/pets"} /> for offset-paginated sets.
+        <Flop.Phoenix.cursor_pagination meta={@meta} path={~p"/pets"} /> for cursor-paginated sets.
+    """
+  end
+end

--- a/lib/flop_phoenix/pagination.ex
+++ b/lib/flop_phoenix/pagination.ex
@@ -48,6 +48,11 @@ defmodule Flop.Phoenix.Pagination do
   def max_pages(:hide, _), do: 0
   def max_pages({:ellipsis, max_pages}, _), do: max_pages
 
+  @spec get_page_link_range(
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: Range.t()
   def get_page_link_range(current_page, max_pages, total_pages) do
     # number of additional pages to show before or after current page
     additional = ceil(max_pages / 2)

--- a/test/flop_phoenix_test.exs
+++ b/test/flop_phoenix_test.exs
@@ -101,6 +101,16 @@ defmodule Flop.PhoenixTest do
              """) == []
     end
 
+    test "raises an error if cursor pagination is in use" do
+      assigns = %{meta: build(:meta_with_cursors)}
+
+      assert_raise Flop.Phoenix.IncorrectPaginationTypeError, fn ->
+        parse_heex(~H"""
+        <Flop.Phoenix.pagination meta={@meta} on_paginate={%JS{}} />
+        """)
+      end
+    end
+
     test "allows to overwrite wrapper class" do
       assigns = %{meta: build(:meta_on_first_page)}
 
@@ -1139,6 +1149,16 @@ defmodule Flop.PhoenixTest do
       assert attribute(nav, "aria-label") == "pagination"
       assert attribute(nav, "class") == "pagination"
       assert attribute(nav, "role") == "navigation"
+    end
+
+    test "raises an error if an offest result set is provided" do
+      assigns = %{meta: build(:meta_on_first_page)}
+
+      assert_raise Flop.Phoenix.IncorrectPaginationTypeError, fn ->
+        parse_heex(~H"""
+        <Flop.Phoenix.cursor_pagination meta={@meta} on_paginate={%JS{}} />
+        """)
+      end
     end
 
     test "allows to overwrite wrapper class" do


### PR DESCRIPTION
In order to provide a more useful error when there is a mismatch between the result set meta and the pagination component, detect this condition and raise an exception.

closes #363 