### PR TITLE
Update flop_phoenix.ex for live_view 1.0 rc.7

### DIFF
--- a/lib/flop_phoenix.ex
+++ b/lib/flop_phoenix.ex
@@ -1166,7 +1166,6 @@ defmodule Flop.Phoenix do
   end
 
   slot :foot,
-    default: nil,
     doc: """
     You can optionally add a `foot`. The inner block will be rendered inside
     a `tfoot` element.


### PR DESCRIPTION
Removes default: nil for `:foot` slot which fails to compile on lv 1.0 rc.7