### PR TITLE
Fix syntax error in dynamic-form-inputs-example

### DIFF
--- a/lib/flop_phoenix.ex
+++ b/lib/flop_phoenix.ex
@@ -1460,7 +1460,7 @@ defmodule Flop.Phoenix do
             <% end %>
           </div>
           <div class="field">
-            <%= PhoenixHTMLHelpers.Form.inputs_for f, :filters, [fields: [{:email, op: :ilike}], offset: 1] fn ff -> %>
+            <%= PhoenixHTMLHelpers.Form.inputs_for f, :filters, [fields: [{:email, op: :ilike}], offset: 1], fn ff -> %>
               <.hidden_inputs_for_filter form={ff} />
               <.input label="E-mail" type="email" field={{ff, :value}} />
             <% end %>


### PR DESCRIPTION
Tiny little baby PR that adds comma to separate arguments in an example