### PR TITLE
Changelog typo: `wrapper_attrs` instead of `wrapper_opts`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ Follow the upgrade guide of version 0.24.0 to update the pagination component
 configuration, including the removal of the application configuration, if you
 haven't done so already.
 
-Remove the `wrapper_opts` from your pagination options and pass them directly
+Remove the `wrapper_attrs` from your pagination options and pass them directly
 as attributes instead.
 
 ```diff


### PR DESCRIPTION
Reference old attribute `wrapper_attrs` instead of `wrapper_opts`.