### PR TITLE
Relax phoenix_live_view requirement

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -63,7 +63,7 @@ defmodule FlopPhoenix.MixProject do
       {:makeup_html, "== 0.2.0", only: :dev, runtime: false},
       {:phoenix, ">= 1.6.0 and < 1.9.0"},
       {:phoenix_html, "~> 4.0"},
-      {:phoenix_live_view, "~> 1.0.6"},
+      {:phoenix_live_view, ">= 1.0.6"},
       {:stream_data, "== 1.2.0", only: [:dev, :test]}
     ]
   end


### PR DESCRIPTION
Phoenix Live View 1.1 was released, but the version is too strict and only allows `1.0.x`

Resolves #480