### PR TITLE
tweak: Sort icon moved within sort_link for clickability

### DIFF
--- a/lib/flop_phoenix/table.ex
+++ b/lib/flop_phoenix/table.ex
@@ -203,14 +203,15 @@ defmodule Flop.Phoenix.Table do
           field={@field}
           label={@label}
           target={@target}
-        />
-        <.arrow
-          direction={@order_direction}
-          symbol_asc={@symbol_asc}
-          symbol_desc={@symbol_desc}
-          symbol_unsorted={@symbol_unsorted}
-          {@symbol_attrs}
-        />
+        >
+          <.arrow
+            direction={@order_direction}
+            symbol_asc={@symbol_asc}
+            symbol_desc={@symbol_desc}
+            symbol_unsorted={@symbol_unsorted}
+            {@symbol_attrs}
+          />
+        </.sort_link>
       </span>
     </th>
     """
@@ -260,10 +261,12 @@ defmodule Flop.Phoenix.Table do
   attr :on_sort, JS
   attr :target, :string
 
+  slot :inner_block
+
   defp sort_link(%{on_sort: nil, path: path} = assigns)
        when is_binary(path) do
     ~H"""
-    <.link patch={@path}>{@label}</.link>
+    <.link patch={@path}>{@label}{render_slot(@inner_block)}</.link>
     """
   end
 
@@ -275,7 +278,7 @@ defmodule Flop.Phoenix.Table do
       phx-target={@target}
       phx-value-order={@field}
     >
-      {@label}
+      {@label}{render_slot(@inner_block)}
     </.link>
     """
   end

--- a/test/flop_phoenix_test.exs
+++ b/test/flop_phoenix_test.exs
@@ -2367,8 +2367,9 @@ defmodule Flop.PhoenixTest do
 
       assert Floki.find(
                html,
-               "a:fl-contains('Email') + span.order-direction"
-             ) == []
+               "a:fl-contains('Email')"
+             )
+             |> Floki.find("span.order-direction") == []
 
       html =
         render_table(%{
@@ -2380,8 +2381,9 @@ defmodule Flop.PhoenixTest do
       assert span =
                find_one(
                  html,
-                 "th a:fl-contains('Email') + span.order-direction"
+                 "th a:fl-contains('Email')"
                )
+               |> Floki.find("span.order-direction")
 
       assert text(span) == "▴"
 
@@ -2395,8 +2397,9 @@ defmodule Flop.PhoenixTest do
       assert span =
                find_one(
                  html,
-                 "th a:fl-contains('Email') + span.order-direction"
+                 "th a:fl-contains('Email')"
                )
+               |> Floki.find("span.order-direction")
 
       assert text(span) == "▾"
     end
@@ -2415,15 +2418,17 @@ defmodule Flop.PhoenixTest do
       assert span =
                find_one(
                  html,
-                 "th a:fl-contains('Name') + span.order-direction"
+                 "th a:fl-contains('Name')"
                )
+               |> Floki.find("span.order-direction")
 
       assert text(span) == "▴"
 
       assert Floki.find(
                html,
-               "a:fl-contains('Email') + span.order-direction"
-             ) == []
+               "a:fl-contains('Email')"
+             )
+             |> Floki.find("span.order-direction") == []
     end
 
     test "allows to set symbol class" do
@@ -2474,8 +2479,9 @@ defmodule Flop.PhoenixTest do
       assert span =
                find_one(
                  html,
-                 "th a:fl-contains('Email') + span.order-direction"
+                 "th a:fl-contains('Email')"
                )
+               |> Floki.find("span.order-direction")
 
       assert text(span) == "random"
     end


### PR DESCRIPTION
Hello! I was torn between making an issue or making the small change as a PR, but I saw that your guidelines generally encourage PRs. Let me know if I should start this as an issue instead.

Usually when dealing with an icon expressing function, the icon is included in the touch target, but that's not the case here. We found our users were confused that the table sort symbol did not toggle the sort. They clicked the sort arrows and thought it was broken when nothing happened.

It seemed to be simple and low-impact to move the sort symbol into `sort_link` component so that clicking either the text _or_ the symbol toggles the sort. What do you think?