### PR TITLE
Add head slot to table

### DIFF
--- a/lib/flop_phoenix.ex
+++ b/lib/flop_phoenix.ex
@@ -1206,6 +1206,20 @@ defmodule Flop.Phoenix do
     ```
     """
 
+  slot :head,
+    doc: """
+    You can optionally add a 2nd `head`. The inner block will be rendered inside
+    the `thead` element and below the table header of the `col` slots.
+
+    ```heex
+    <Flop.Phoenix.table>
+      <:head>
+        <tr><td>Total: <span class="total">{@total}</span></td></tr>
+      </:head>
+    </Flop.Phoenix.table>
+    ```
+    """
+
   def table(%{path: nil, on_sort: nil}) do
     raise Flop.Phoenix.PathOrJSError, component: :table
   end
@@ -1226,6 +1240,7 @@ defmodule Flop.Phoenix do
             caption={@caption}
             col={@col}
             foot={@foot}
+            head={@head}
             on_sort={@on_sort}
             id={@id}
             items={@items}
@@ -1244,6 +1259,7 @@ defmodule Flop.Phoenix do
           caption={@caption}
           col={@col}
           foot={@foot}
+          head={@head}
           on_sort={@on_sort}
           id={@id}
           items={@items}

--- a/lib/flop_phoenix/table.ex
+++ b/lib/flop_phoenix/table.ex
@@ -44,6 +44,7 @@ defmodule Flop.Phoenix.Table do
   attr :col, :any
   attr :items, :list, required: true
   attr :foot, :any, required: true
+  attr :head, :any, required: true
   attr :row_id, :any, default: nil
   attr :row_click, JS, default: nil
   attr :row_item, :any, required: true
@@ -92,6 +93,9 @@ defmodule Flop.Phoenix.Table do
             target={@target}
           />
         </tr>
+        <%= if @head != [] do %>
+          {render_slot(@head)}
+        <% end %>
       </thead>
       <tbody
         id={@id <> "-tbody"}

--- a/test/flop_phoenix_test.exs
+++ b/test/flop_phoenix_test.exs
@@ -2522,6 +2522,35 @@ defmodule Flop.PhoenixTest do
       assert [_, _, _, _, _] = Floki.find(rows, "td")
     end
 
+    test "renders table head" do
+      assigns = %{}
+
+      html =
+        parse_heex(~H"""
+        <Flop.Phoenix.table
+          on_sort={JS.push("sort")}
+          id="user-table"
+          items={[%{name: "George"}]}
+          meta={%Flop.Meta{flop: %Flop{}}}
+        >
+          <:head>
+            <tr>
+              <td>snap</td>
+            </tr>
+          </:head>
+          <:col :let={pet} label="Name" field={:name}>{pet.name}</:col>
+        </Flop.Phoenix.table>
+        """)
+
+      assert [
+               {"table", _,
+                [
+                  {"thead", [], [_, {"tr", [], [{"td", [], ["snap"]}]}]},
+                  {"tbody", _, _}
+                ]}
+             ] = html
+    end
+
     test "renders table foot" do
       assigns = %{}
 


### PR DESCRIPTION
There is already a `:foot` slot allowing to show additional data fields on the bottom of a table (e.g. for totals). This PR adds the same for the `head` of a table.

<img width="758" height="304" alt="image" src="https://github.com/user-attachments/assets/7dfcfa62-8ec8-4115-91a1-a609a91795ce" />

The `:head` slot is rendered after `:col`/`:action` slots in a new `tr` element. Elsewise, it is identical to the `:foot` slot implementation.

Resolves issue #485 