### PR TITLE
Fix syntax error in options array

### DIFF
--- a/lib/flop_phoenix.ex
+++ b/lib/flop_phoenix.ex
@@ -1338,7 +1338,7 @@ defmodule Flop.Phoenix do
           prompt: "",
           options: [
             {gettext("young"), :young},
-            {gettext("old"), :old)}
+            {gettext("old"), :old}
           ]
         ]
       ]}


### PR DESCRIPTION
In the `@doc` for `filter_fields` a `)` caused syntax error in the example.