### PR TITLE
fix: Support table empty state for LiveView streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixed
+
+- Allow explicitly rendering the table empty state when using a LiveView
+  stream.
+
 ## [0.26.1] - 2026-06-11
 
 ### Changed

--- a/lib/flop_phoenix.ex
+++ b/lib/flop_phoenix.ex
@@ -993,6 +993,15 @@ defmodule Flop.Phoenix do
     by the query.
     """
 
+  attr :empty, :boolean,
+    default: false,
+    doc: """
+    Whether to render the configured no-results content instead of the table.
+    Empty lists are detected automatically. Set this attribute when using an
+    empty LiveView stream, since the component cannot infer a stream's current
+    contents.
+    """
+
   attr :meta, Flop.Meta,
     required: true,
     doc: "The `Flop.Meta` struct returned by the query function."
@@ -1231,7 +1240,7 @@ defmodule Flop.Phoenix do
       |> assign_new(:id, fn -> table_id(meta.schema) end)
 
     ~H"""
-    <%= if @items == [] do %>
+    <%= if @empty || @items == [] do %>
       {@opts[:no_results_content]}
     <% else %>
       <%= if @opts[:container] do %>

--- a/test/flop_phoenix_test.exs
+++ b/test/flop_phoenix_test.exs
@@ -18,6 +18,7 @@ defmodule Flop.PhoenixTest do
   @route_helper_opts [%{}, :pets]
 
   attr :caption, :string, default: nil
+  attr :empty, :boolean, default: false
   attr :on_sort, JS, default: nil
   attr :id, :string, default: "some-table"
   attr :meta, Flop.Meta, default: %Flop.Meta{flop: %Flop{}}
@@ -34,6 +35,7 @@ defmodule Flop.PhoenixTest do
     parse_heex(~H"""
     <Flop.Phoenix.table
       caption={@caption}
+      empty={@empty}
       on_sort={@on_sort}
       id={@id}
       items={@items}
@@ -1698,6 +1700,7 @@ defmodule Flop.PhoenixTest do
         """)
 
       assert [tr_1, tr_2] = Floki.find(html, "tbody tr")
+      assert attribute(find_one(html, "tbody"), "phx-update") == "stream"
       assert attribute(tr_1, "id") == "pets-1"
       assert attribute(tr_2, "id") == "pets-2"
     end
@@ -2426,6 +2429,27 @@ defmodule Flop.PhoenixTest do
 
     test "renders notice if item list is empty" do
       assert [{"p", [], ["No results."]}] = render_table(%{items: []})
+    end
+
+    test "renders notice if a stream is explicitly empty" do
+      stream = LiveStream.new(:pets, 0, [], [])
+
+      assert [{"p", [], ["No results."]}] =
+               render_table(%{items: stream, empty: true})
+    end
+
+    test "allows to set no_results_content for an explicitly empty stream" do
+      stream = LiveStream.new(:pets, 0, [], [])
+
+      assert render_table(%{
+               items: stream,
+               empty: true,
+               opts: [no_results_content: custom_no_results_content()]
+             }) == [{"div", [], ["Nothing!"]}]
+    end
+
+    test "empty overrides a non-empty list" do
+      assert [{"p", [], ["No results."]}] = render_table(%{empty: true})
     end
 
     test "allows to set no_results_content" do


### PR DESCRIPTION
Add a documented, default-false boolean `empty` attribute to `Flop.Phoenix.table/1` so a caller that still has the fetched result list can explicitly report whether a stream reset is empty. Use that flag alongside the existing `items == []` condition, preserving automatic detection and behavior for list-backed tables while allowing empty streams to render the existing `no_results_content`. Keep the decision in the public component before it delegates to `Flop.Phoenix.Table.render/1`, so non-empty streams retain their `phx-update="stream"` tbody and row-ID behavior without a new helper or internal stream inspection.

`Flop.Phoenix.table/1` currently selects its no-results content only when `items == []`. A `Phoenix.LiveView.LiveStream` is always a struct, so an empty reset stream bypasses that branch and renders the table instead of the configured empty state. A stream represents pending DOM operations rather than the complete client-side collection, which means the component cannot reliably infer emptiness by enumerating it or inspecting its internal fields. The existing workaround forces callers to replace an empty stream with a list, obscuring the stream-specific rendering contract.

Render an empty list without the new attribute and confirm the default no-results content still appears; Render an empty `LiveStream` with `empty={true}` and confirm the no-results content appears instead of a table.

Fixes #438
